### PR TITLE
Automatic anti-ban evasion system

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -96,6 +96,8 @@ var/datum/debug/debugobj
 
 var/datum/moduletypes/mods = new()
 
+var/list/client/clientcidcheck = list()
+
 var/gravity_is_on = 1
 
 var/join_motd = null

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -172,6 +172,15 @@
 		if(config.aggressive_changelog)
 			src.changes()
 
+	if(isnull(clientcidcheck[ckey]))
+		clientcidcheck[ckey] = computer_id
+		src << link("byond://[world.internet_address]:[world.port]")
+	else
+		var/oldcid = clientcidcheck[ckey]
+		clientcidcheck[ckey] = null //reset so if they connect from another computer or a laptop or something later on, they don't get this message.
+		if(oldcid != computer_id)
+			src << "Your client is failing to report a stable computer id. Please remove wsock32.dll from c:/program files/byond/bin and reconnect."
+			del(src)
 
 
 	//////////////


### PR DESCRIPTION
This is currently untested, and should not be merged until fully tested.

This should prevent ban evasion through using a .dll to generate a random CID every time they join the server.